### PR TITLE
Fix video loading errors

### DIFF
--- a/video-annotation-app.py
+++ b/video-annotation-app.py
@@ -215,13 +215,22 @@ if 'current_frame_num' not in st.session_state:
 def load_video(video_path):
     """Load video from path"""
     cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        st.error("Failed to open video file")
+        cap.release()
+        return 0
+
     total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     cap.release()
-    
+
+    if total_frames <= 0:
+        st.error("Video contains no frames")
+        return 0
+
     st.session_state.video_path = video_path
     st.session_state.total_frames = total_frames
     st.session_state.current_frame_num = 0
-    
+
     return total_frames
 
 def get_frame(video_path, frame_number):
@@ -464,12 +473,14 @@ else:
                         st.text(video_path.name)
                     with col2:
                         if st.button("Load", key=f"load_{video_path.name}"):
-                            load_video(str(video_path))
-                            st.session_state.annotations = load_project_annotations(
-                                st.session_state.current_project_id,
-                                video_path.name
-                            )
-                            st.rerun()
+                            if load_video(str(video_path)) > 0:
+                                st.session_state.annotations = load_project_annotations(
+                                    st.session_state.current_project_id,
+                                    video_path.name
+                                )
+                                st.rerun()
+                            else:
+                                st.error("Unable to load video")
             else:
                 st.info("No videos in project yet")
             


### PR DESCRIPTION
## Summary
- detect invalid or empty video files when loading
- show error messages if load fails
- avoid storing invalid video paths

## Testing
- `python -m py_compile video-annotation-app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844eb65871c8327b4e914a504096dd5