### PR TITLE
Add YOLOv8 detection integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This repository is the starting point for a modular Streamlit-based video annota
 - Per-frame annotation persistence (COCO JSON, PASCAL VOC XML)
 - Model training and export
 - Download/export of annotated data
+- Built-in YOLOv8 detection to pre-populate annotations
+
+During annotation you can run automatic detection using YOLOv8 from the sidebar.
+Adjust the confidence slider before starting detection to control the threshold.
+Detection counts per frame are displayed alongside annotation metrics.
 
 ---
 

--- a/models/detection.py
+++ b/models/detection.py
@@ -1,0 +1,54 @@
+from typing import Dict, List, Tuple
+
+import cv2
+
+try:
+    from ultralytics import YOLO
+except Exception as e:  # ultralytics may not be installed when importing
+    YOLO = None
+
+
+class YOLODetector:
+    """Wrapper around YOLOv8 model."""
+
+    def __init__(self, model_name: str = "yolov8n.pt", conf: float = 0.25):
+        if YOLO is None:
+            raise ImportError("ultralytics package is required for YOLOv8 detection")
+        self.model = YOLO(model_name)
+        self.conf = conf
+
+    def set_conf(self, conf: float) -> None:
+        self.conf = conf
+
+    def detect_frame(self, frame) -> List[Dict]:
+        """Run detection on a single frame and return list of detections."""
+        results = self.model(frame, conf=self.conf)[0]
+        detections = []
+        for box in results.boxes:
+            x1, y1, x2, y2 = [int(v) for v in box.xyxy[0].tolist()]
+            cls_id = int(box.cls[0])
+            conf = float(box.conf[0])
+            class_name = self.model.names[cls_id]
+            detections.append({
+                "class": class_name,
+                "bbox": [x1, y1, x2, y2],
+                "conf": conf,
+            })
+        return detections
+
+    def detect_video(self, path: str) -> Tuple[Dict[int, List[Dict]], Dict[int, int]]:
+        """Run detection on a video and return annotations and counts per frame."""
+        cap = cv2.VideoCapture(path)
+        annotations = {}
+        counts = {}
+        frame_num = 0
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            detections = self.detect_frame(frame)
+            annotations[frame_num] = detections
+            counts[frame_num] = len(detections)
+            frame_num += 1
+        cap.release()
+        return annotations, counts

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 Pillow
 streamlit-drawable-canvas
 pytest
+ultralytics


### PR DESCRIPTION
## Summary
- add `models/detection.py` wrapper for YOLOv8
- integrate detection module in app sidebar with confidence slider
- record per-frame detection counts and show metric
- document detection feature in README
- add `ultralytics` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f15052bc8327abdae22027bf70da